### PR TITLE
feat: add --no-verify to skip checksum verification 

### DIFF
--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -89,6 +89,7 @@ async fn test_get_release_checksum() {
         tmpdir: None,
         os: None,
         arch: None,
+        no_verify: false,
     };
     let os = args.os.get_or_insert_default();
     let arch = args.arch.get_or_insert_default();

--- a/tests/install_test.rs
+++ b/tests/install_test.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
+use semver::Version as SemVersion;
 use tempfile::{tempdir, TempDir};
+use wasmedgeup::system;
 use wasmedgeup::{
-    api::{releases, ReleasesFilter, WasmEdgeApiClient},
+    api::{releases, Asset, ReleasesFilter, WasmEdgeApiClient},
     cli::{CommandContext, CommandExecutor},
     commands::install::InstallArgs,
 };
@@ -12,13 +14,40 @@ use test_utils::setup_test_environment;
 
 const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
 
-async fn execute_install_test(version: String, install_dir: PathBuf, tmpdir: TempDir) {
+/// From a list of versions (tags), return the first prerelease that has a
+/// published asset for the current platform (checked via a HEAD request).
+async fn first_available_prerelease(versions: Vec<SemVersion>) -> Option<SemVersion> {
+    let specs = system::detect();
+    let http = reqwest::Client::new();
+
+    for v in versions.into_iter().filter(|v| !v.pre.is_empty()) {
+        let asset = Asset::new(&v, &specs.os.os_type, &specs.os.arch);
+        let url = match asset.url() {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+        if let Ok(resp) = http.head(url.clone()).send().await {
+            if resp.status().is_success() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+async fn execute_install_test(
+    version: String,
+    install_dir: PathBuf,
+    tmpdir: TempDir,
+    no_verify: bool,
+) {
     let args = InstallArgs {
         version,
         path: Some(install_dir.clone()),
         tmpdir: Some(tmpdir.path().to_path_buf()),
         os: None,
         arch: None,
+        no_verify,
     };
 
     let client = WasmEdgeApiClient::default();
@@ -59,7 +88,7 @@ async fn test_install_latest_version() {
         // Give Windows a moment to release any file handles
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir).await;
+    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir, false).await;
 }
 
 #[tokio::test]
@@ -76,5 +105,13 @@ async fn test_install_prerelease_version() {
         // Give Windows a moment to release any file handles
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir).await;
+    let Some(prerelease) = first_available_prerelease(all_releases).await else {
+        eprintln!("No prerelease with assets found; skipping");
+        return;
+    };
+    assert!(
+        !prerelease.pre.is_empty(),
+        "Selected version is not a prerelease"
+    );
+    execute_install_test(prerelease.to_string(), install_dir, tmpdir, true).await;
 }

--- a/tests/plugin_install_test.rs
+++ b/tests/plugin_install_test.rs
@@ -19,6 +19,7 @@ async fn execute_runtime_install(version: String, install_dir: &Path, tmpdir: &T
         tmpdir: Some(tmpdir.path().to_path_buf()),
         os: None,
         arch: None,
+        no_verify: false,
     };
 
     let client = WasmEdgeApiClient::default();


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?
- This option can be used to install pre-release versions which do not have `SHA256SUM` for checksum verification.
<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Adds a `--no-verify` flag in `install` command
<!-- Summarize the key changes included in this PR. -->

## How has this been tested?

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
